### PR TITLE
added 'type' keyword to the list

### DIFF
--- a/brush.js
+++ b/brush.js
@@ -8,7 +8,7 @@ function Brush() {
     'interface let new null package private protected ' +
     'static return super switch ' +
     'this throw true try typeof var while with yield' +
-    ' any bool declare get module never number public readonly set string'; // TypeScript-specific, everything above is common with JavaScript
+    ' any bool declare get module never number public readonly set string type'; // TypeScript-specific, everything above is common with JavaScript
 
   this.regexList = [
     {


### PR DESCRIPTION
Hey! Not sure if anyone still intends to maintain this, but I added the brush to my blog yesterday and I noticed that the `type` keyword that defines type aliases wasn't highlighted, so I added it here.
